### PR TITLE
Fix: Pad with a leading zero in hex triplets.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,9 @@ const averageColor = colors => {
   }, [0, 0, 0]);
 
   return '#' +
-    Math.round(totalR).toString(16).padEnd(2, '0') +
-    Math.round(totalG).toString(16).padEnd(2, '0') +
-    Math.round(totalB).toString(16).padEnd(2, '0');
+    Math.round(totalR).toString(16).padStart(2, '0') +
+    Math.round(totalG).toString(16).padStart(2, '0') +
+    Math.round(totalB).toString(16).padStart(2, '0');
 };
 
 module.exports = averageColor;

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ test('color average', t => {
   t.equal(averageColor(['#fff', '#fff', '#fff', '#fff']), '#ffffff');
   t.equal(averageColor(['#00f', '#0f0', '#f00']), '#555555');
   t.equal(averageColor(['#121212', '#121212']), '#121212');
-  t.equal(averageColor(['#ff0000', '#ff0000']), '#ff0000')
+  t.equal(averageColor(['#ff0000', '#ff0000']), '#ff0000');
+  t.equal(averageColor(['#030303', '#050505']), '#040404');
   t.end();
 });


### PR DESCRIPTION
## Issue
When RGB values are converted to hex values, single digit hex values are padded with zeros at the end of the string.

An example of this bug can be found here:
https://codesandbox.io/s/color-array-average-leading-zero-8n1ik?file=/src/index.js

## Fix
Single digit hex values should be padded with zeros at the start of the string.

## Changes
- Uses padStart instead of padEnd when the return string is created.
- Adds testing for the array `['#030303', '#050505']` which is now passing.